### PR TITLE
Added distructions of thrown items into damaging blocks

### DIFF
--- a/src/main/java/org/terasology/damagingblocks/DamageSystem.java
+++ b/src/main/java/org/terasology/damagingblocks/DamageSystem.java
@@ -30,7 +30,9 @@ import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.characters.events.OnEnterBlockEvent;
 import org.terasology.logic.health.DoDamageEvent;
 import org.terasology.logic.health.EngineDamageTypes;
+import org.terasology.logic.inventory.PickupComponent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.BlockEntityRegistry;
@@ -68,6 +70,27 @@ public class DamageSystem extends BaseComponentSystem implements UpdateSubscribe
                 // set the next damage time
                 damaging.nextDamageTime = gameTime + damaging.timeBetweenDamage;
                 entity.saveComponent(damaging);
+            }
+        }
+
+        //Checks all pickable items to see if they're inside a lava block and destroys them if they are.
+        //Can be used to check for existence of components, but no blocks currently have damage components on them.
+        //Could just catch events that are sent from the position update where it checks if items transitioned to another block
+        for (EntityRef entity : entityManager.getEntitiesWith(PickupComponent.class))
+        {
+            LocationComponent loc = entity.getComponent(LocationComponent.class);
+            if (loc == null)
+            {
+                continue;
+            }
+
+            Vector3f vLocation = loc.getWorldPosition();
+
+            Block block = worldProvider.getBlock(vLocation);
+            //if (entity.hasComponent(DamagingBlockComponent.class))
+            if (block.isLava())
+            {
+                entity.destroy();
             }
         }
     }


### PR DESCRIPTION
Contains:
    This is a partial fix for #1697, which only takes care of the basic need of items being destroyed when touching lava (as is specified)

How to test:
    Get an item, drop into lava, mourn its loss :)

Outstanding:
    As specified in the comments, there could be several implementations of this functionality. The others rely on items sending events when entering blocks; This would in turn be caught by this system and managed in a proper fashion if the block would be lava/has a damaging component.
    Adding a damaging component optionally to lava blocks is also an option, but first there needs to be some more exploration into the optionality of the modules as I've asked in the slack chat.

In short:
- [ ] Rely on Damaging component
- [ ] Use other system for block checking (main engine events)
- [ ] Optionally add Damaging components to blocks which deserve them
