### PR TITLE
Major re-write to avoid explicit reference to lava.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,10 @@ Defines the rate and amount of damage which would be inflicted on the player.
 <pre>
 public class DamagingBlockComponent implements Component {
     public int timeBetweenDamage = 1000;        //The rate (value in milliseconds) at which the damage is inflicted
-    public int blockDamage = 20;                //The damage the block inflicts to the player
-    @Replicate(FieldReplicateType.SERVER_TO_OWNER)
-    public long nextDamageTime;                 //Helper variable for the system to know when to inflict damage
+    public int blockDamage;                     //The damage the block inflicts to the player
 }
 </pre>
 
 ## DamageSystem
 
-The DamageSystem is the code which applies the damage to players or destroys blocks if on DamagingBlocks. 
-
-There are two types of damage which the system deals:
-*Damage resulting from the player being inside the block (i.e. Player in a pool of Lava)
-*Damage resulting from the player entering and touching the block (i.e. Player running into Cacti)
-
-For further details, please refer to the Javadocs at [DamagingSystems](https://github.com/Terasology/DamagingBlocks/blob/master/src/main/java/org/terasology/damagingblocks/DamageSystem.java)
+The DamageSystem is the code which applies the damage to players or destroys blocks if on DamagingBlocks.

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 ﻿{
      "id" : "DamagingBlocks",
-     "version" : "0.1.2-SNAPSHOT",
+     "version" : "0.2.0-SNAPSHOT",
      "author" : "Sérgio Domingues <sergio.mieic@gmail.com>",
      "displayName" : "DamagingBlocks",
      "description" : "Allows players to take damage from blocks.",

--- a/src/main/java/org/terasology/damagingblocks/component/DamagedByBlockComponent.java
+++ b/src/main/java/org/terasology/damagingblocks/component/DamagedByBlockComponent.java
@@ -16,11 +16,13 @@
 package org.terasology.damagingblocks.component;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.network.FieldReplicateType;
+import org.terasology.network.Replicate;
 
 /**
- * A block which damages entities that touch it.
+ * Marks entities which are being affected by damaging blocks.
  */
-public class DamagingBlockComponent implements Component {
-    public int timeBetweenDamage = 1000;
-    public int blockDamage;
+public class DamagedByBlockComponent implements Component {
+    @Replicate(FieldReplicateType.SERVER_TO_OWNER)
+    public long nextDamageTime;
 }


### PR DESCRIPTION
Use DamagingBlockComponent for damaging blocks only. Use DamagedByBlockComponent internally to keep track of when to apply damage instead.

This PR is intended to make the module compatible with engine PR #3481, but removing the lava flag necessitated lots of other changes, too.