### PR TITLE
Update to depend on Health module and remove unused imports

### DIFF
--- a/src/main/java/org/terasology/damagingblocks/DamageSystem.java
+++ b/src/main/java/org/terasology/damagingblocks/DamageSystem.java
@@ -27,18 +27,15 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
-import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.characters.events.OnEnterBlockEvent;
-import org.terasology.logic.health.DoDamageEvent;
+import org.terasology.logic.health.event.DoDamageEvent;
 import org.terasology.logic.health.EngineDamageTypes;
 import org.terasology.logic.inventory.PickupComponent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
-import org.terasology.world.block.Block;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class DamageSystem extends BaseComponentSystem implements UpdateSubscriberSystem {


### PR DESCRIPTION
API Changes introduced in https://github.com/MovingBlocks/Terasology/pull/3677 and [Health module](https://github.com/Terasology/Health)